### PR TITLE
feat(admin): add member management page with role controls, deactivation, and account deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ npm install @supabase/supabase-js @supabase/ssr
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=...
 NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+SUPABASE_SERVICE_ROLE_KEY=...
 ```
+
+`SUPABASE_SERVICE_ROLE_KEY` is required for admin member management actions (deactivate and permanent account deletion). Keep it server-only and never expose it to client components.
 
 3. Use the initialized clients:
 

--- a/app/(authenticated)/admin/dashboard/page.tsx
+++ b/app/(authenticated)/admin/dashboard/page.tsx
@@ -145,11 +145,11 @@ export default async function AdminDashboardPage() {
               Dashboard
             </a>
             <a
-              href="/people"
+              href="/admin/members"
               className="flex items-center gap-3 px-3 py-2 rounded-lg text-[#64748b] hover:bg-[#f1f5f9] hover:text-[#1e293b] transition-colors"
             >
               <Users className="w-5 h-5" />
-              People
+              Members
             </a>
             <a
               href="/events"
@@ -267,10 +267,10 @@ export default async function AdminDashboardPage() {
 
               <div className="space-y-3">
                 <a
-                  href="/people"
+                  href="/admin/members"
                   className="w-full flex items-center justify-between gap-3 px-4 py-3 rounded-lg bg-[#1e293b] text-white hover:bg-[#334155] transition-colors"
                 >
-                  <span className="text-sm font-medium">Manage Members / Students</span>
+                  <span className="text-sm font-medium">Manage Members</span>
                   <ArrowRight className="w-4 h-4" />
                 </a>
 

--- a/app/(authenticated)/admin/members/page.tsx
+++ b/app/(authenticated)/admin/members/page.tsx
@@ -1,0 +1,344 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Search, Loader2, Shield, AlertCircle, CheckCircle2, ArrowLeft } from 'lucide-react';
+
+type CombinedRole = 'Admin' | 'Officer' | 'Student' | 'Staff' | 'Visitor';
+
+type Member = {
+  id: string;
+  email: string;
+  fullName: string;
+  personType: string;
+  role: CombinedRole;
+  operatorRole: 'Admin' | 'Taker' | null;
+  isActive: boolean;
+};
+
+const roleOptions: CombinedRole[] = ['Admin', 'Officer', 'Student', 'Staff', 'Visitor'];
+
+export default function AdminMembersPage() {
+  const [members, setMembers] = useState<Member[]>([]);
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [savingMemberId, setSavingMemberId] = useState<string | null>(null);
+  const [deactivatingMemberId, setDeactivatingMemberId] = useState<string | null>(null);
+  const [deletingMemberId, setDeletingMemberId] = useState<string | null>(null);
+  const [draftRoles, setDraftRoles] = useState<Record<string, CombinedRole>>({});
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const loadMembers = useCallback(async (searchTerm?: string) => {
+    setLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const search = (searchTerm ?? query).trim();
+      const response = await fetch(`/api/admin/members${search ? `?q=${encodeURIComponent(search)}` : ''}`);
+      const payload = (await response.json()) as { error?: string; members?: Member[] };
+
+      if (!response.ok || !payload.members) {
+        throw new Error(payload.error ?? 'Failed to load members.');
+      }
+
+      setMembers(payload.members);
+      setDraftRoles(
+        payload.members.reduce<Record<string, CombinedRole>>((acc, member) => {
+          acc[member.id] = member.role;
+          return acc;
+        }, {})
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load members.';
+      setErrorMessage(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [query]);
+
+  useEffect(() => {
+    void loadMembers('');
+  }, [loadMembers]);
+
+  const sortedMembers = useMemo(() => {
+    return [...members].sort((left, right) => left.fullName.localeCompare(right.fullName));
+  }, [members]);
+
+  const handleSearch = async () => {
+    await loadMembers(query);
+  };
+
+  const handleSaveRole = async (memberId: string) => {
+    const selectedRole = draftRoles[memberId];
+
+    if (!selectedRole) {
+      return;
+    }
+
+    setSavingMemberId(memberId);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    try {
+      const response = await fetch(`/api/admin/members/${memberId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'set-role', role: selectedRole }),
+      });
+
+      const payload = (await response.json()) as { error?: string; message?: string };
+
+      if (!response.ok) {
+        throw new Error(payload.error ?? 'Failed to update role.');
+      }
+
+      setSuccessMessage(payload.message ?? 'Role updated.');
+      await loadMembers(query);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update role.';
+      setErrorMessage(message);
+    } finally {
+      setSavingMemberId(null);
+    }
+  };
+
+  const handleDeactivate = async (memberId: string, memberName: string) => {
+    const confirmed = window.confirm(`Deactivate ${memberName}? This blocks sign in but keeps records.`);
+
+    if (!confirmed) {
+      return;
+    }
+
+    setDeactivatingMemberId(memberId);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    try {
+      const response = await fetch(`/api/admin/members/${memberId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'deactivate' }),
+      });
+
+      const payload = (await response.json()) as { error?: string; message?: string };
+
+      if (!response.ok) {
+        throw new Error(payload.error ?? 'Failed to deactivate member.');
+      }
+
+      setSuccessMessage(payload.message ?? 'Member deactivated.');
+      await loadMembers(query);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to deactivate member.';
+      setErrorMessage(message);
+    } finally {
+      setDeactivatingMemberId(null);
+    }
+  };
+
+  const handleDelete = async (memberId: string, memberName: string) => {
+    const confirmed = window.confirm(
+      `Permanently delete ${memberName}? This removes auth access and linked person record.`
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    setDeletingMemberId(memberId);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    try {
+      const response = await fetch(`/api/admin/members/${memberId}`, {
+        method: 'DELETE',
+      });
+
+      const payload = (await response.json()) as { error?: string; message?: string };
+
+      if (!response.ok) {
+        throw new Error(payload.error ?? 'Failed to delete member account.');
+      }
+
+      setSuccessMessage(payload.message ?? 'Member deleted.');
+      await loadMembers(query);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to delete member account.';
+      setErrorMessage(message);
+    } finally {
+      setDeletingMemberId(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f8f9fa] p-8">
+      <div className="mb-8">
+        <button
+          onClick={() => window.history.back()}
+          className="mb-4 inline-flex items-center gap-2 rounded-lg border border-[#e2e8f0] bg-white px-3 py-2 text-sm text-[#0f172a] hover:bg-[#f8f9fa] transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back
+        </button>
+        <div className="flex items-center gap-3 mb-2">
+          <Shield className="w-8 h-8 text-[#1e293b]" />
+          <h1 className="text-3xl font-bold text-[#0f172a]">Member Management</h1>
+        </div>
+        <p className="text-[#64748b]">
+          Query members, assign roles (Admin, Officer, Student, Staff, Visitor), deactivate users, or permanently
+          delete accounts.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-xl border border-[#e2e8f0] p-4 mb-4 shadow-sm">
+        <div className="flex gap-3">
+          <div className="relative flex-1">
+            <Search className="w-5 h-5 text-[#64748b] absolute left-3 top-1/2 -translate-y-1/2" />
+            <input
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  void handleSearch();
+                }
+              }}
+              placeholder="Search by member name, email, type, or role"
+              className="w-full rounded-lg border border-[#e2e8f0] pl-10 pr-4 py-2 text-[#0f172a] placeholder-[#64748b] focus:outline-none focus:ring-1 focus:ring-[#1e293b]"
+            />
+          </div>
+          <button
+            onClick={() => void handleSearch()}
+            className="px-4 py-2 rounded-lg bg-[#1e293b] text-white hover:bg-[#334155] transition-colors"
+          >
+            Search
+          </button>
+        </div>
+      </div>
+
+      {errorMessage ? (
+        <div className="mb-4 rounded-lg border border-[#fecaca] bg-[#fef2f2] px-4 py-3 text-[#b91c1c] flex items-center gap-2">
+          <AlertCircle className="w-4 h-4" />
+          <span className="text-sm">{errorMessage}</span>
+        </div>
+      ) : null}
+
+      {successMessage ? (
+        <div className="mb-4 rounded-lg border border-[#bbf7d0] bg-[#f0fdf4] px-4 py-3 text-[#166534] flex items-center gap-2">
+          <CheckCircle2 className="w-4 h-4" />
+          <span className="text-sm">{successMessage}</span>
+        </div>
+      ) : null}
+
+      <div className="bg-white rounded-xl border border-[#e2e8f0] shadow-sm overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="bg-[#f8f9fa] border-b border-[#e2e8f0]">
+                <th className="px-4 py-3 text-left text-sm font-semibold text-[#0f172a]">Member</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-[#0f172a]">Base Type</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-[#0f172a]">Role</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-[#0f172a]">Status</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-[#0f172a]">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-10 text-center text-[#64748b]">
+                    <div className="inline-flex items-center gap-2">
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      Loading members...
+                    </div>
+                  </td>
+                </tr>
+              ) : sortedMembers.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-4 py-10 text-center text-[#64748b]">
+                    No members found.
+                  </td>
+                </tr>
+              ) : (
+                sortedMembers.map((member) => {
+                  const selectedRole = draftRoles[member.id] ?? member.role;
+                  const canSave = selectedRole !== member.role;
+                  const roleUpdateBusy = savingMemberId === member.id;
+                  const deactivationBusy = deactivatingMemberId === member.id;
+                  const deletionBusy = deletingMemberId === member.id;
+                  const busy = roleUpdateBusy || deactivationBusy || deletionBusy;
+
+                  return (
+                    <tr key={member.id} className="border-b border-[#e2e8f0] align-top">
+                      <td className="px-4 py-4">
+                        <p className="text-sm font-medium text-[#0f172a]">{member.fullName}</p>
+                        <p className="text-xs text-[#64748b]">{member.email}</p>
+                      </td>
+                      <td className="px-4 py-4 text-sm text-[#0f172a]">{member.personType}</td>
+                      <td className="px-4 py-4">
+                        <div className="flex items-center gap-2">
+                          <select
+                            value={selectedRole}
+                            disabled={busy}
+                            onChange={(event) =>
+                              setDraftRoles((previous) => ({
+                                ...previous,
+                                [member.id]: event.target.value as CombinedRole,
+                              }))
+                            }
+                            className="rounded-lg border border-[#e2e8f0] px-3 py-2 text-sm text-[#0f172a] focus:outline-none focus:ring-1 focus:ring-[#1e293b]"
+                          >
+                            {roleOptions.map((roleOption) => (
+                              <option key={roleOption} value={roleOption}>
+                                {roleOption}
+                              </option>
+                            ))}
+                          </select>
+                          <button
+                            disabled={!canSave || roleUpdateBusy || deactivationBusy || deletionBusy}
+                            onClick={() => void handleSaveRole(member.id)}
+                            className="px-3 py-2 rounded-lg text-sm bg-[#1e293b] text-white disabled:opacity-50 hover:bg-[#334155] transition-colors"
+                          >
+                            {roleUpdateBusy ? 'Saving...' : 'Save'}
+                          </button>
+                        </div>
+                      </td>
+                      <td className="px-4 py-4">
+                        <span
+                          className={`inline-flex rounded-full px-2.5 py-1 text-xs font-medium ${
+                            member.isActive
+                              ? 'bg-[#dcfce7] text-[#166534]'
+                              : 'bg-[#f1f5f9] text-[#334155]'
+                          }`}
+                        >
+                          {member.isActive ? 'Active' : 'Inactive'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-4">
+                        <div className="flex items-center gap-2">
+                          <button
+                            disabled={busy}
+                            onClick={() => void handleDeactivate(member.id, member.fullName)}
+                            className="px-3 py-2 rounded-lg text-xs border border-[#e2e8f0] text-[#0f172a] hover:bg-[#f8f9fa] disabled:opacity-50 transition-colors"
+                          >
+                            {deactivationBusy ? 'Deactivating...' : 'Deactivate'}
+                          </button>
+                          <button
+                            disabled={busy}
+                            onClick={() => void handleDelete(member.id, member.fullName)}
+                            className="px-3 py-2 rounded-lg text-xs bg-[#ef4444] text-white hover:bg-[#dc2626] disabled:opacity-50 transition-colors"
+                          >
+                            {deletionBusy ? 'Deleting...' : 'Delete Account'}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/members/[memberId]/route.ts
+++ b/app/api/admin/members/[memberId]/route.ts
@@ -1,0 +1,263 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+
+type CombinedRole = 'Admin' | 'Officer' | 'Student' | 'Staff' | 'Visitor';
+
+async function assertAdminAccess() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+
+  const { data: adminRole, error: roleError } = await supabase
+    .from('school_operator_roles')
+    .select('id')
+    .eq('user_id', user.id)
+    .eq('operator_role', 'Admin')
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (roleError || !adminRole) {
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+
+  return { userId: user.id };
+}
+
+function isPromotedOperatorRole(role: CombinedRole) {
+  return role === 'Admin' || role === 'Officer';
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ memberId: string }> }
+) {
+  const access = await assertAdminAccess();
+
+  if ('error' in access) {
+    return access.error;
+  }
+
+  const actorId = access.userId;
+  const { memberId } = await params;
+
+  if (memberId === actorId) {
+    return NextResponse.json({ error: 'You cannot modify your own account from this page.' }, { status: 400 });
+  }
+
+  let adminClient;
+  try {
+    adminClient = createAdminClient();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Server configuration error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  const payload = (await request.json()) as { action?: 'set-role' | 'deactivate'; role?: CombinedRole };
+
+  const { data: targetAuthUser, error: targetError } = await adminClient
+    .from('auth_users')
+    .select('id, person_id, role_id')
+    .eq('id', memberId)
+    .maybeSingle();
+
+  if (targetError) {
+    return NextResponse.json({ error: targetError.message }, { status: 500 });
+  }
+
+  if (!targetAuthUser) {
+    return NextResponse.json({ error: 'Member not found.' }, { status: 404 });
+  }
+
+  const { data: person, error: personError } = await adminClient
+    .from('person_registry')
+    .select('id, person_type, is_active')
+    .eq('id', targetAuthUser.person_id)
+    .maybeSingle();
+
+  if (personError) {
+    return NextResponse.json({ error: personError.message }, { status: 500 });
+  }
+
+  if (!person) {
+    return NextResponse.json({ error: 'Person record not found.' }, { status: 404 });
+  }
+
+  if (payload.action === 'deactivate') {
+    const [{ error: deactivatePersonError }, { error: deactivateRoleError }, authBanResult] = await Promise.all([
+      adminClient.from('person_registry').update({ is_active: false }).eq('id', person.id),
+      adminClient.from('school_operator_roles').update({ is_active: false }).eq('user_id', memberId),
+      adminClient.auth.admin.updateUserById(memberId, { ban_duration: '876000h' }),
+    ]);
+
+    if (deactivatePersonError) {
+      return NextResponse.json({ error: deactivatePersonError.message }, { status: 500 });
+    }
+
+    if (deactivateRoleError) {
+      return NextResponse.json({ error: deactivateRoleError.message }, { status: 500 });
+    }
+
+    if (authBanResult.error) {
+      return NextResponse.json({ error: authBanResult.error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, message: 'Member account deactivated.' });
+  }
+
+  if (payload.action !== 'set-role' || !payload.role) {
+    return NextResponse.json({ error: 'Invalid action payload.' }, { status: 400 });
+  }
+
+  const selectedRole = payload.role;
+
+  if (isPromotedOperatorRole(selectedRole) && person.person_type !== 'Staff') {
+    return NextResponse.json(
+      {
+        error: 'Only members with Staff base role can be promoted to Admin or Officer.',
+      },
+      { status: 400 }
+    );
+  }
+
+  if (selectedRole === 'Admin' || selectedRole === 'Officer') {
+    const operatorRole = selectedRole === 'Admin' ? 'Admin' : 'Taker';
+
+    const { data: upsertedRole, error: upsertRoleError } = await adminClient
+      .from('school_operator_roles')
+      .upsert(
+        {
+          user_id: memberId,
+          operator_role: operatorRole,
+          is_active: true,
+          assigned_by: actorId,
+          assigned_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id' }
+      )
+      .select('id')
+      .single();
+
+    if (upsertRoleError || !upsertedRole) {
+      return NextResponse.json({ error: upsertRoleError?.message ?? 'Failed to set operator role.' }, { status: 500 });
+    }
+
+    const [{ error: updateAuthUsersError }, unbanResult] = await Promise.all([
+      adminClient.from('auth_users').update({ role_id: upsertedRole.id }).eq('id', memberId),
+      adminClient.auth.admin.updateUserById(memberId, { ban_duration: 'none' }),
+    ]);
+
+    if (updateAuthUsersError) {
+      return NextResponse.json({ error: updateAuthUsersError.message }, { status: 500 });
+    }
+
+    if (unbanResult.error) {
+      return NextResponse.json({ error: unbanResult.error.message }, { status: 500 });
+    }
+
+    if (!person.is_active) {
+      const { error: activatePersonError } = await adminClient
+        .from('person_registry')
+        .update({ is_active: true })
+        .eq('id', person.id);
+
+      if (activatePersonError) {
+        return NextResponse.json({ error: activatePersonError.message }, { status: 500 });
+      }
+    }
+
+    return NextResponse.json({ success: true, message: `Role updated to ${selectedRole}.` });
+  }
+
+  const [{ error: updatePersonError }, { error: clearOperatorError }, { error: updateAuthUsersError }, unbanResult] =
+    await Promise.all([
+      adminClient
+        .from('person_registry')
+        .update({ person_type: selectedRole, is_active: true })
+        .eq('id', person.id),
+      adminClient.from('school_operator_roles').update({ is_active: false }).eq('user_id', memberId),
+      adminClient.from('auth_users').update({ role_id: null }).eq('id', memberId),
+      adminClient.auth.admin.updateUserById(memberId, { ban_duration: 'none' }),
+    ]);
+
+  if (updatePersonError) {
+    return NextResponse.json({ error: updatePersonError.message }, { status: 500 });
+  }
+
+  if (clearOperatorError) {
+    return NextResponse.json({ error: clearOperatorError.message }, { status: 500 });
+  }
+
+  if (updateAuthUsersError) {
+    return NextResponse.json({ error: updateAuthUsersError.message }, { status: 500 });
+  }
+
+  if (unbanResult.error) {
+    return NextResponse.json({ error: unbanResult.error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, message: `Role updated to ${selectedRole}.` });
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ memberId: string }> }
+) {
+  const access = await assertAdminAccess();
+
+  if ('error' in access) {
+    return access.error;
+  }
+
+  const actorId = access.userId;
+  const { memberId } = await params;
+
+  if (memberId === actorId) {
+    return NextResponse.json({ error: 'You cannot delete your own account from this page.' }, { status: 400 });
+  }
+
+  let adminClient;
+  try {
+    adminClient = createAdminClient();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Server configuration error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  const { data: targetAuthUser, error: targetError } = await adminClient
+    .from('auth_users')
+    .select('id, person_id')
+    .eq('id', memberId)
+    .maybeSingle();
+
+  if (targetError) {
+    return NextResponse.json({ error: targetError.message }, { status: 500 });
+  }
+
+  if (!targetAuthUser) {
+    return NextResponse.json({ error: 'Member not found.' }, { status: 404 });
+  }
+
+  const { error: deleteAuthError } = await adminClient.auth.admin.deleteUser(memberId);
+
+  if (deleteAuthError) {
+    return NextResponse.json({ error: deleteAuthError.message }, { status: 500 });
+  }
+
+  const { error: deletePersonError } = await adminClient
+    .from('person_registry')
+    .delete()
+    .eq('id', targetAuthUser.person_id);
+
+  if (deletePersonError) {
+    return NextResponse.json({ error: deletePersonError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, message: 'Member account permanently deleted.' });
+}

--- a/app/api/admin/members/route.ts
+++ b/app/api/admin/members/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+
+type PersonType = 'Student' | 'Staff' | 'Visitor' | 'Special Guest';
+type OperatorRole = 'Admin' | 'Taker';
+type CombinedRole = 'Admin' | 'Officer' | 'Student' | 'Staff' | 'Visitor';
+
+function toCombinedRole(personType: PersonType, operatorRole: OperatorRole | null): CombinedRole {
+  if (operatorRole === 'Admin') {
+    return 'Admin';
+  }
+
+  if (operatorRole === 'Taker') {
+    return 'Officer';
+  }
+
+  if (personType === 'Special Guest') {
+    return 'Visitor';
+  }
+
+  return personType;
+}
+
+async function assertAdminAccess() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+
+  const { data: adminRole, error: roleError } = await supabase
+    .from('school_operator_roles')
+    .select('id')
+    .eq('user_id', user.id)
+    .eq('operator_role', 'Admin')
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (roleError || !adminRole) {
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+
+  return { userId: user.id };
+}
+
+export async function GET(request: NextRequest) {
+  const access = await assertAdminAccess();
+
+  if ('error' in access) {
+    return access.error;
+  }
+
+  let adminClient;
+  try {
+    adminClient = createAdminClient();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Server configuration error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  const searchQuery = request.nextUrl.searchParams.get('q')?.trim().toLowerCase() ?? '';
+
+  const { data: authUsers, error: authUsersError } = await adminClient
+    .from('auth_users')
+    .select('id, email, person_id, role_id, created_at')
+    .order('created_at', { ascending: false })
+    .limit(500);
+
+  if (authUsersError) {
+    return NextResponse.json({ error: authUsersError.message }, { status: 500 });
+  }
+
+  const personIds = (authUsers ?? []).map((item) => item.person_id).filter(Boolean);
+  const userIds = (authUsers ?? []).map((item) => item.id);
+
+  const [{ data: people, error: peopleError }, { data: operatorRoles, error: operatorRolesError }] =
+    await Promise.all([
+      personIds.length
+        ? adminClient
+            .from('person_registry')
+            .select('id, full_name, person_type, is_active')
+            .in('id', personIds)
+        : Promise.resolve({ data: [], error: null }),
+      userIds.length
+        ? adminClient
+            .from('school_operator_roles')
+            .select('id, user_id, operator_role, is_active')
+            .in('user_id', userIds)
+        : Promise.resolve({ data: [], error: null }),
+    ]);
+
+  if (peopleError) {
+    return NextResponse.json({ error: peopleError.message }, { status: 500 });
+  }
+
+  if (operatorRolesError) {
+    return NextResponse.json({ error: operatorRolesError.message }, { status: 500 });
+  }
+
+  const peopleById = new Map((people ?? []).map((person) => [person.id, person]));
+  const roleByUserId = new Map((operatorRoles ?? []).map((role) => [role.user_id, role]));
+
+  const members = (authUsers ?? [])
+    .map((authUser) => {
+      const person = peopleById.get(authUser.person_id);
+
+      if (!person) {
+        return null;
+      }
+
+      const roleRecord = roleByUserId.get(authUser.id);
+      const activeOperatorRole = roleRecord?.is_active ? (roleRecord.operator_role as OperatorRole) : null;
+
+      return {
+        id: authUser.id,
+        email: authUser.email,
+        fullName: person.full_name,
+        personType: person.person_type,
+        personId: person.id,
+        operatorRole: activeOperatorRole,
+        role: toCombinedRole(person.person_type as PersonType, activeOperatorRole),
+        isActive: person.is_active,
+      };
+    })
+    .filter((item): item is NonNullable<typeof item> => Boolean(item));
+
+  const filteredMembers = searchQuery
+    ? members.filter((member) => {
+        const haystack = `${member.fullName} ${member.email} ${member.personType} ${member.role}`.toLowerCase();
+        return haystack.includes(searchQuery);
+      })
+    : members;
+
+  return NextResponse.json({ members: filteredMembers });
+}

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,17 @@
+import { createClient } from '@supabase/supabase-js';
+
+export function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_URL environment variables.');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}


### PR DESCRIPTION
Adds a new admin member management UI with search/query, combined role selector (Admin, Officer, Student, Staff, Visitor), and row-level actions.
Implements admin-only member APIs for:
listing/searching members,
updating roles,
deactivating accounts (soft remove),
permanently deleting accounts.
Enforces business rule: only users whose base type is Staff can be promoted to Admin or Officer.
Adds server-only Supabase admin client usage for privileged operations and auth-user deletion.
Updates admin dashboard links to point to the new members page.
Adds a Back button on the members page for quick navigation.
Documents required SUPABASE_SERVICE_ROLE_KEY setup for admin member-management operations.
Lint passes with no new errors from these changes (existing unrelated warnings remain in other pages).